### PR TITLE
Fixed relative path bug in production mode and sourcemap support

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -375,7 +375,7 @@ module.exports = {
 
       // This plugin cleans out your .tmp/public folder before lifting.
       new CleanWebpackPlugin(['public'], {
-        root: path.resolve(__dirname, '..', '.tmp'),
+        root: path.resolve(__dirname, '..', '..', '.tmp'),
         verbose: true,
         dry: false
       }),
@@ -386,11 +386,11 @@ module.exports = {
       new CopyWebpackPlugin([
         {
           from: './assets/images',
-          to: path.resolve(__dirname, '..', '.tmp', 'public', 'images')
+          to: path.resolve(__dirname, '..', '..', '.tmp', 'public', 'images')
         },
         {
           from: './assets/fonts',
-          to: path.resolve(__dirname, '..', '.tmp', 'public', 'fonts')
+          to: path.resolve(__dirname, '..', '..', '.tmp', 'public', 'fonts')
         }
       ]),
 

--- a/config/webpack.js
+++ b/config/webpack.js
@@ -18,6 +18,12 @@ var CopyWebpackPlugin = require('copy-webpack-plugin');
  */
 
 module.exports.webpack = {
+  /***************************************************************************
+  *                                                                          *
+  * Allow source-mapping if not production mode                              *
+  *                                                                          *
+  ***************************************************************************/
+  devtool: process.env.NODE_ENV === 'production' ? '' : 'source-map',
 
   /***************************************************************************
   *                                                                          *
@@ -49,7 +55,7 @@ module.exports.webpack = {
   ***************************************************************************/
   module: {
     rules: [
-      // Extract less files
+      // Extract css files
       {
         test: /\.css$/,
         loader: ExtractTextPlugin.extract({ use: 'css-loader' })
@@ -58,6 +64,24 @@ module.exports.webpack = {
       {
         test: /\.less$/,
         loader: ExtractTextPlugin.extract({ use: 'css-loader!less-loader' })
+      },
+      // Extract sass files
+      {
+        test: /\.(sass|scss)$/,
+        loader: ExtractTextPlugin.extract({ use: 'css-loader?sourceMap!sass-loader?sourceMap' })
+      },
+      // For ExtractTextPlugin images need to be moved if used in styles for background etc
+      {
+        test: /\.(png|jpe?g|gif|svg)$/,
+        use: [{
+          loader: 'file-loader',
+          options: {
+            name: '[path][name].[ext]',
+            context: 'assets/images',
+            outputPath: 'images/',
+            publicPath: '../'
+          }
+        }]
       }
     ],
   },

--- a/package.json
+++ b/package.json
@@ -18,9 +18,12 @@
     "css-loader": "0.27.3",
     "ejs-loader": "0.3.0",
     "extract-text-webpack-plugin": "2.1.0",
+    "file-loader": "^0.11.2",
     "less": "2.7.2",
     "less-loader": "4.0.1",
+    "node-sass": "^4.5.3",
     "sails.io.js": "1.1.9",
+    "sass-loader": "^6.0.6",
     "socket.io-client": "1.7.3"
   },
   "scripts": {


### PR DESCRIPTION
In production mode the distribution folder `.tmp` was generated in `config` folder